### PR TITLE
Force Generation of SSL URLs

### DIFF
--- a/Resources/Views/backend/swag_tiny_mce_custom_font/tinymce_override.js
+++ b/Resources/Views/backend/swag_tiny_mce_custom_font/tinymce_override.js
@@ -7,7 +7,7 @@ Ext.define('Shopware.form.field.TinyMCEUnfiltered', {
 
         me.editor = Ext.apply(me.editor, {
             theme_advanced_fonts: "{$tinyMceCustomFontConfig.fontNames}",
-            content_css: '{url controller="tiny_mce_custom_font"}?_dc=' + new Date().getTime(),
+            content_css: '{url controller="tiny_mce_custom_font" forceSecure}?_dc=' + new Date().getTime(),
         });
 
         me.callOverridden();


### PR DESCRIPTION
It looks as if there is an issue with backends that use SSL. TinyMCE seems to do modify the relative path generated by Smarty to an absolute URL using the http protocol. That results in mixed content errors.